### PR TITLE
Shebang error when installing

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
 Copyright 2020 IRT SystemX
 
@@ -14,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#!/usr/bin/env node
 import * as program from 'commander';
 import { l } from './utils/logs';
 import { CLI } from './cli';


### PR DESCRIPTION
The file commands.ts has a shebang after a comment block. It should be at the start

```mvanmeerbeck@mvanmeerbeck-pc:/var/www/xdev/bnc-hlf$ npm link

> bnc@0.0.1 prepare /var/www/xdev/bnc-hlf
> npm run build


> bnc@0.0.1 build /var/www/xdev/bnc-hlf
> npm run clean && tsc


> bnc@0.0.1 clean /var/www/xdev/bnc-hlf
> rimraf dist

src/command.ts:17:1 - error TS18026: '#!' can only be used at the start of a file.

17 #!/usr/bin/env node
   

src/command.ts:17:16 - error TS1005: ';' expected.

17 #!/usr/bin/env node
                  ~~~~

```